### PR TITLE
Fips distutils fix

### DIFF
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -102,7 +102,7 @@ class upload(PyPIRCCommand):
             'content': (os.path.basename(filename),content),
             'filetype': command,
             'pyversion': pyversion,
-            'md5_digest': hashlib.md5(content).hexdigest(),
+            'sha256_digest': hashlib.sha256(content).hexdigest(),
 
             # additional meta-data
             'metadata_version': '1.0',

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -102,6 +102,7 @@ class upload(PyPIRCCommand):
             'content': (os.path.basename(filename),content),
             'filetype': command,
             'pyversion': pyversion,
+            'md5_digest': hashlib.md5(content).hexdigest(),
 
             # additional meta-data
             'metadata_version': '1.0',
@@ -120,16 +121,6 @@ class upload(PyPIRCCommand):
             'requires': meta.get_requires(),
             'obsoletes': meta.get_obsoletes(),
             }
-        try:
-            digest = hashlib.md5(content).hexdigest()
-        except ValueError as e:
-            msg = 'calculating md5 checksum failed: %s' % e
-            self.announce(msg, log.ERROR)
-            if not hashlib.get_fips_mode():
-                # this really shouldn't fail
-                raise
-        else:
-            data['md5_digest'] = digest
         comment = ''
         if command == 'bdist_rpm':
             dist, version, id = platform.dist()

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -130,7 +130,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
         # what did we send ?
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-length'], '2162')
+        self.assertEqual(headers['Content-length'], '2197')
         content_type = headers['Content-type']
         self.assertTrue(content_type.startswith('multipart/form-data'))
         self.assertEqual(self.last_open.req.get_method(), 'POST')
@@ -166,7 +166,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         cmd.run()
 
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-length'], '2172')
+        self.assertEqual(headers['Content-length'], '2207')
         self.assertIn(b'long description\r', self.last_open.req.data)
 
     def test_upload_fails(self):

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -3,7 +3,6 @@ import os
 import unittest
 import unittest.mock as mock
 from urllib.request import HTTPError
-import hashlib
 
 from test.support import run_unittest
 
@@ -131,11 +130,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
         # what did we send ?
         headers = dict(self.last_open.req.headers)
-        if hashlib.get_fips_mode():
-            # md5 hash is omitted
-            self.assertEqual(headers['Content-length'], '2020')
-        else:
-            self.assertEqual(headers['Content-length'], '2162')
+        self.assertEqual(headers['Content-length'], '2162')
         content_type = headers['Content-type']
         self.assertTrue(content_type.startswith('multipart/form-data'))
         self.assertEqual(self.last_open.req.get_method(), 'POST')
@@ -171,11 +166,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         cmd.run()
 
         headers = dict(self.last_open.req.headers)
-        if hashlib.get_fips_mode():
-            # md5 hash is omitted
-            self.assertEqual(headers['Content-length'], '2030')
-        else:
-            self.assertEqual(headers['Content-length'], '2172')
+        self.assertEqual(headers['Content-length'], '2172')
         self.assertIn(b'long description\r', self.last_open.req.data)
 
     def test_upload_fails(self):


### PR DESCRIPTION
Use SHA256 instead of MD5 in distutils upload command and update tests accordingly.