### PR TITLE
Preliminary PEP 573 (module state access) implementation

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -147,23 +147,56 @@ Implementing functions and methods
    value of the function as exposed in Python.  The function must return a new
    reference.
 
+   The function signature is::
+
+      PyObject *PyCFunction(PyObject *self,
+                            PyObject *const *args);
 
 .. c:type:: PyCFunctionWithKeywords
 
    Type of the functions used to implement Python callables in C
    with signature :const:`METH_VARARGS | METH_KEYWORDS`.
+   The function signature is::
+
+      PyObject *PyCFunctionWithKeywords(PyObject *self,
+                                        PyObject *const *args,
+                                        PyObject *kwargs);
 
 
 .. c:type:: _PyCFunctionFast
 
    Type of the functions used to implement Python callables in C
    with signature :const:`METH_FASTCALL`.
+   The function signature is::
 
+      PyObject *_PyCFunctionFast(PyObject *self,
+                                 PyObject *const *args,
+                                 Py_ssize_t nargs);
 
 .. c:type:: _PyCFunctionFastWithKeywords
 
    Type of the functions used to implement Python callables in C
    with signature :const:`METH_FASTCALL | METH_KEYWORDS`.
+   The function signature is::
+
+      PyObject *_PyCFunctionFastWithKeywords(PyObject *self,
+                                             PyObject *const *args,
+                                             Py_ssize_t nargs,
+                                             PyObject *kwnames);
+
+.. c:type:: PyCMethod
+
+   Type of the functions used to implement Python callables in C
+   with signature :const:`METH_METHOD | METH_FASTCALL | METH_KEYWORDS`.
+   The function signature is::
+
+      PyObject *PyCMethod(PyObject *self,
+                          PyTypeObject *defining_class,
+                          PyObject *const *args,
+                          Py_ssize_t nargs,
+                          PyObject *kwnames)
+
+   .. versionadded:: 3.9
 
 
 .. c:type:: PyMethodDef
@@ -197,9 +230,7 @@ The :attr:`ml_flags` field is a bitfield which can include the following flags.
 The individual flags indicate either a calling convention or a binding
 convention.
 
-There are four basic calling conventions for positional arguments
-and two of them can be combined with :const:`METH_KEYWORDS` to support
-also keyword arguments.  So there are a total of 6 calling conventions:
+There are these calling conventions:
 
 .. data:: METH_VARARGS
 
@@ -248,6 +279,19 @@ also keyword arguments.  So there are a total of 6 calling conventions:
    This is not part of the :ref:`limited API <stable>`.
 
    .. versionadded:: 3.7
+
+
+.. data:: METH_METHOD | METH_FASTCALL | METH_KEYWORDS
+
+   Extension of :const:`METH_FASTCALL | METH_KEYWORDS` supporting the *defining
+   class*, that is, the class that contains the method in question.
+   The defining class might be a superclass of ``Py_TYPE(self)``.
+
+   The method needs to be of type :c:type:`PyCMethod`, the same as for
+   ``METH_FASTCALL | METH_KEYWORDS`` with ``defining_class`` argument added after
+   ``self``.
+
+   .. versionadded:: 3.9
 
 
 .. data:: METH_NOARGS

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -109,7 +109,7 @@ Type Objects
 
    .. versionadded:: 3.4
 
-.. c:function:: void* PyType_GetModule(PyTypeObject *type)
+.. c:function:: PyObject* PyType_GetModule(PyTypeObject *type)
 
    Return the module object associated with the given type when the type was
    created using :c:func:`PyType_FromModuleAndSpec`.
@@ -161,7 +161,7 @@ The following functions and structs are used to create
 
 .. c:function:: PyObject* PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 
-   Equivalent to ``PyType_FromModuleAndSpec(NULL, spec, NULL)``.
+   Equivalent to ``PyType_FromModuleAndSpec(NULL, spec, bases)``.
 
    .. versionadded:: 3.3
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -109,6 +109,30 @@ Type Objects
 
    .. versionadded:: 3.4
 
+.. c:function:: void* PyType_GetModule(PyTypeObject *type)
+
+   Return the module object associated with the given type when the type was
+   created using :c:func:`PyType_FromModuleAndSpec`.
+
+   If no module is associated with the given type, sets :py:class:`TypeError`
+   and returns ``NULL``.
+
+   .. versionadded:: 3.9
+
+.. c:function:: void* PyType_GetModuleState(PyTypeObject *type)
+
+   Return the state of the module object associated with the given type.
+   This is a shortcut for calling :c:func:`PyModule_GetState()` on the result
+   of :c:func:`PyType_GetModule`.
+
+   If no module is associated with the given type, sets :py:class:`TypeError`
+   and returns ``NULL``.
+
+   If the *type* has an associated module but its state is ``NULL``,
+   returns ``NULL`` without setting an exception.
+
+   .. versionadded:: 3.9
+
 
 Creating Heap-Allocated Types
 .............................
@@ -116,7 +140,7 @@ Creating Heap-Allocated Types
 The following functions and structs are used to create
 :ref:`heap types <heap-types>`.
 
-.. c:function:: PyObject* PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
+.. c:function:: PyObject* PyType_FromModuleAndSpec(PyObject *module, PyType_Spec *spec, PyObject *bases)
 
    Creates and returns a heap type object from the *spec*
    (:const:`Py_TPFLAGS_HEAPTYPE`).
@@ -127,7 +151,17 @@ The following functions and structs are used to create
    If *bases* is ``NULL``, the *Py_tp_base* slot is used instead.
    If that also is ``NULL``, the new type derives from :class:`object`.
 
+   The *module* must be a module object or ``NULL``.
+   If not ``NULL``, the module is associated with the new type and can later be
+   retreived with :c:func:`PyType_GetModule`.
+
    This function calls :c:func:`PyType_Ready` on the new type.
+
+   .. versionadded:: 3.9
+
+.. c:function:: PyObject* PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
+
+   Equivalent to ``PyType_FromModuleAndSpec(NULL, spec, NULL)``.
 
    .. versionadded:: 3.3
 

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -2,8 +2,6 @@
 #  error "this header file must not be included directly"
 #endif
 
-PyAPI_DATA(PyTypeObject) PyCMethod_Type;
-
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyCFunction_GET_FUNCTION(func) \
@@ -18,7 +16,7 @@ PyAPI_DATA(PyTypeObject) PyCMethod_Type;
          ((PyCMethodObject *)func) -> mm_class : NULL)
 
 typedef struct {
-    PyObject_HEAD
+    PyObject_VAR_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */
     PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
     PyObject    *m_module; /* The __module__ attribute, can be anything */

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -1,0 +1,20 @@
+#ifndef Py_CPYTHON_METHODOBJECT_H
+#  error "this header file must not be included directly"
+#endif
+/* Macros for direct access to these values. Type checks are *not*
+   done, so use with care. */
+#define PyCFunction_GET_FUNCTION(func) \
+        (((PyCFunctionObject *)func) -> m_ml -> ml_meth)
+#define PyCFunction_GET_SELF(func) \
+        (((PyCFunctionObject *)func) -> m_ml -> ml_flags & METH_STATIC ? \
+         NULL : ((PyCFunctionObject *)func) -> m_self)
+#define PyCFunction_GET_FLAGS(func) \
+        (((PyCFunctionObject *)func) -> m_ml -> ml_flags)
+typedef struct {
+    PyObject_HEAD
+    PyMethodDef *m_ml; /* Description of the C function to call */
+    PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
+    PyObject    *m_module; /* The __module__ attribute, can be anything */
+    PyObject    *m_weakreflist; /* List of weak references */
+    vectorcallfunc vectorcall;
+} PyCFunctionObject;

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -2,6 +2,8 @@
 #  error "this header file must not be included directly"
 #endif
 
+PyAPI_DATA(PyTypeObject) PyCMethod_Type;
+
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyCFunction_GET_FUNCTION(func) \
@@ -16,7 +18,7 @@
          ((PyCMethodObject *)func) -> mm_class : NULL)
 
 typedef struct {
-    PyObject_VAR_HEAD
+    PyObject_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */
     PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
     PyObject    *m_module; /* The __module__ attribute, can be anything */

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -1,6 +1,9 @@
 #ifndef Py_CPYTHON_METHODOBJECT_H
 #  error "this header file must not be included directly"
 #endif
+
+PyAPI_DATA(PyTypeObject) PyCMethod_Type;
+
 /* Macros for direct access to these values. Type checks are *not*
    done, so use with care. */
 #define PyCFunction_GET_FUNCTION(func) \
@@ -10,6 +13,10 @@
          NULL : ((PyCFunctionObject *)func) -> m_self)
 #define PyCFunction_GET_FLAGS(func) \
         (((PyCFunctionObject *)func) -> m_ml -> ml_flags)
+#define PyCFunction_GET_CLASS(func) \
+    (((PyCFunctionObject *)func) -> m_ml -> ml_flags & METH_METHOD ? \
+         ((PyCMethodObject *)func) -> mm_class : NULL)
+
 typedef struct {
     PyObject_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */
@@ -18,3 +25,8 @@ typedef struct {
     PyObject    *m_weakreflist; /* List of weak references */
     vectorcallfunc vectorcall;
 } PyCFunctionObject;
+
+typedef struct {
+    PyCFunctionObject func;
+    PyTypeObject *mm_class; /* Class that defines this method */
+} PyCMethodObject;

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -289,6 +289,7 @@ typedef struct _heaptypeobject {
     PyBufferProcs as_buffer;
     PyObject *ht_name, *ht_slots, *ht_qualname;
     struct _dictkeysobject *ht_cached_keys;
+    PyObject *ht_module;
     /* here are optional user slots, followed by the members. */
 } PyHeapTypeObject;
 

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -26,17 +26,6 @@ PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);
 PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *);
 
-/* Macros for direct access to these values. Type checks are *not*
-   done, so use with care. */
-#ifndef Py_LIMITED_API
-#define PyCFunction_GET_FUNCTION(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_meth)
-#define PyCFunction_GET_SELF(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_flags & METH_STATIC ? \
-         NULL : ((PyCFunctionObject *)func) -> m_self)
-#define PyCFunction_GET_FLAGS(func) \
-        (((PyCFunctionObject *)func) -> m_ml -> ml_flags)
-#endif
 Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyCFunction_Call(PyObject *, PyObject *, PyObject *);
 
 struct PyMethodDef {
@@ -85,14 +74,11 @@ PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *,
 #endif
 
 #ifndef Py_LIMITED_API
-typedef struct {
-    PyObject_HEAD
-    PyMethodDef *m_ml; /* Description of the C function to call */
-    PyObject    *m_self; /* Passed as 'self' arg to the C func, can be NULL */
-    PyObject    *m_module; /* The __module__ attribute, can be anything */
-    PyObject    *m_weakreflist; /* List of weak references */
-    vectorcallfunc vectorcall;
-} PyCFunctionObject;
+
+#define Py_CPYTHON_METHODOBJECT_H
+#include  "cpython/methodobject.h"
+#undef Py_CPYTHON_METHODOBJECT_H
+
 #endif
 
 #ifdef __cplusplus

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -13,7 +13,7 @@ extern "C" {
 
 PyAPI_DATA(PyTypeObject) PyCFunction_Type;
 
-#define PyCFunction_Check(op) Py_IS_TYPE(op, &PyCFunction_Type)
+#define PyCFunction_Check(op) (Py_IS_TYPE(op, &PyCFunction_Type) || (PyType_IsSubtype(Py_TYPE(op), &PyCFunction_Type)))
 
 typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
 typedef PyObject *(*_PyCFunctionFast) (PyObject *, PyObject *const *, Py_ssize_t);

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -13,7 +13,7 @@ extern "C" {
 
 PyAPI_DATA(PyTypeObject) PyCFunction_Type;
 
-#define PyCFunction_Check(op) (Py_IS_TYPE(op, &PyCFunction_Type) || (PyType_IsSubtype(Py_TYPE(op), &PyCFunction_Type)))
+#define PyCFunction_Check(op) Py_IS_TYPE(op, &PyCFunction_Type)
 
 typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
 typedef PyObject *(*_PyCFunctionFast) (PyObject *, PyObject *const *, Py_ssize_t);

--- a/Include/object.h
+++ b/Include/object.h
@@ -213,6 +213,9 @@ PyAPI_FUNC(PyObject*) PyType_FromSpecWithBases(PyType_Spec*, PyObject*);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03040000
 PyAPI_FUNC(void*) PyType_GetSlot(PyTypeObject*, int);
 #endif
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03090000
+PyAPI_FUNC(PyObject*) PyType_FromModuleAndSpec(PyObject *, PyType_Spec *, PyObject *);
+#endif
 
 /* Generic type check */
 PyAPI_FUNC(int) PyType_IsSubtype(PyTypeObject *, PyTypeObject *);

--- a/Include/object.h
+++ b/Include/object.h
@@ -215,6 +215,8 @@ PyAPI_FUNC(void*) PyType_GetSlot(PyTypeObject*, int);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03090000
 PyAPI_FUNC(PyObject*) PyType_FromModuleAndSpec(PyObject *, PyType_Spec *, PyObject *);
+PyAPI_FUNC(PyObject *) PyType_GetModule(struct _typeobject *);
+PyAPI_FUNC(void *) PyType_GetModuleState(struct _typeobject *);
 #endif
 
 /* Generic type check */

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -13,6 +13,8 @@ import threading
 import time
 import unittest
 import weakref
+import importlib.machinery
+import importlib.util
 from test import support
 from test.support import MISSING_C_DOCSTRINGS
 from test.support.script_helper import assert_python_failure, assert_python_ok
@@ -772,6 +774,77 @@ class PyMemPymallocDebugTests(PyMemDebugTests):
 class PyMemDefaultTests(PyMemDebugTests):
     # test default allocator of Python compiled in debug mode
     PYTHONMALLOC = ''
+
+
+class Test_ModuleStateAccess(unittest.TestCase):
+    """Test access to module start (PEP 573)"""
+
+    # The C part of the tests lives in _testmultiphase, in a module called
+    # _testmultiphase_meth_state_access.
+    # This module has multi-phase initialization, unlike _testcapi.
+
+    def setUp(self):
+        fullname = '_testmultiphase_meth_state_access'  # XXX
+        origin = importlib.util.find_spec('_testmultiphase').origin
+        loader = importlib.machinery.ExtensionFileLoader(fullname, origin)
+        spec = importlib.util.spec_from_loader(fullname, loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        self.module = module
+
+    def test_subclass_get_module(self):
+        """PyType_GetModule for defining_class"""
+        class StateAccessType_Subclass(self.module.StateAccessType):
+            pass
+
+        instance = StateAccessType_Subclass()
+        self.assertIs(instance.get_defining_module(), self.module)
+
+    def test_subclass_get_module_with_super(self):
+        class StateAccessType_Subclass(self.module.StateAccessType):
+            def get_defining_module(self):
+                return super().get_defining_module()
+
+        instance = StateAccessType_Subclass()
+        self.assertIs(instance.get_defining_module(), self.module)
+
+    def test_state_access(self):
+        """Checks methods defined with and without argument clinic
+
+        This tests a no-arg method (get_count) and a method with
+        both a positional and keyword argument.
+        """
+
+        a = self.module.StateAccessType()
+        b = self.module.StateAccessType()
+
+        methods = {
+            'clinic': a.increment_count_clinic,
+            'noclinic': a.increment_count_noclinic,
+        }
+
+        for name, increment_count in methods.items():
+            with self.subTest(name):
+                self.assertEqual(a.get_count(), b.get_count())
+                self.assertEqual(a.get_count(), 0)
+
+                increment_count()
+                self.assertEqual(a.get_count(), b.get_count())
+                self.assertEqual(a.get_count(), 1)
+
+                increment_count(3)
+                self.assertEqual(a.get_count(), b.get_count())
+                self.assertEqual(a.get_count(), 4)
+
+                increment_count(-2, twice=True)
+                self.assertEqual(a.get_count(), b.get_count())
+                self.assertEqual(a.get_count(), 0)
+
+                with self.assertRaises(TypeError):
+                    increment_count(thrice=3)
+
+                with self.assertRaises(TypeError):
+                    increment_count(1, 2, 3)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -267,6 +267,66 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
                 self.assertEqual(module.__name__, name)
                 self.assertEqual(module.__doc__, "Module named in %s" % lang)
 
+    def test_subclass_get_module(self):
+        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
+
+        class StateAccessType_Subclass(testmultiphase.StateAccessType):
+            pass
+
+        ex = StateAccessType_Subclass()
+
+        self.assertIs(ex.get_defining_module(), testmultiphase)
+
+    def test_subclass_get_module_with_super(self):
+        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
+
+        class StateAccessType_Subclass(testmultiphase.StateAccessType):
+            def get_defining_module(self):
+                return super().get_defining_module()
+
+        ex = StateAccessType_Subclass()
+
+        self.assertIs(ex.get_defining_module(), testmultiphase)
+
+    def test_state_counter(self):
+        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
+
+        a = testmultiphase.StateAccessType()
+        b = testmultiphase.StateAccessType()
+
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), 0)
+
+        a.increment_count()
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), 1)
+
+        b.increment_count()
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), 2)
+
+        a.decrement_count()
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), 1)
+
+        b.decrement_count()
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), 0)
+
+        a.decrement_count(2)
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), -2)
+
+        a.decrement_count(3, twice=True)
+        self.assertEqual(a.get_count(), b.get_count())
+        self.assertEqual(a.get_count(), -8)
+
+        with self.assertRaises(TypeError):
+            a.decrement_count(thrice=3)
+
+        with self.assertRaises(TypeError):
+            a.decrement_count(1, 2, 3)
+
 
 (Frozen_MultiPhaseExtensionModuleTests,
  Source_MultiPhaseExtensionModuleTests

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -267,66 +267,6 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
                 self.assertEqual(module.__name__, name)
                 self.assertEqual(module.__doc__, "Module named in %s" % lang)
 
-    def test_subclass_get_module(self):
-        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
-
-        class StateAccessType_Subclass(testmultiphase.StateAccessType):
-            pass
-
-        ex = StateAccessType_Subclass()
-
-        self.assertIs(ex.get_defining_module(), testmultiphase)
-
-    def test_subclass_get_module_with_super(self):
-        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
-
-        class StateAccessType_Subclass(testmultiphase.StateAccessType):
-            def get_defining_module(self):
-                return super().get_defining_module()
-
-        ex = StateAccessType_Subclass()
-
-        self.assertIs(ex.get_defining_module(), testmultiphase)
-
-    def test_state_counter(self):
-        testmultiphase = self.load_module_by_name("_testmultiphase_meth_state_access")
-
-        a = testmultiphase.StateAccessType()
-        b = testmultiphase.StateAccessType()
-
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), 0)
-
-        a.increment_count()
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), 1)
-
-        b.increment_count()
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), 2)
-
-        a.decrement_count()
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), 1)
-
-        b.decrement_count()
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), 0)
-
-        a.decrement_count(2)
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), -2)
-
-        a.decrement_count(3, twice=True)
-        self.assertEqual(a.get_count(), b.get_count())
-        self.assertEqual(a.get_count(), -8)
-
-        with self.assertRaises(TypeError):
-            a.decrement_count(thrice=3)
-
-        with self.assertRaises(TypeError):
-            a.decrement_count(1, 2, 3)
-
 
 (Frozen_MultiPhaseExtensionModuleTests,
  Source_MultiPhaseExtensionModuleTests

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1322,7 +1322,7 @@ class SizeofTest(unittest.TestCase):
                   '3P'                  # PyMappingMethods
                   '10P'                 # PySequenceMethods
                   '2P'                  # PyBufferProcs
-                  '4P')
+                  '5P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
         check(newstyleclass, s + calcsize("2nP2n0P") + 8 + 5*calcsize("n2P"))

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1117,7 +1117,7 @@ class SizeofTest(unittest.TestCase):
         # buffer
         # XXX
         # builtin_function_or_method
-        check(len, size('5P'))
+        check(len, vsize('5P'))
         # bytearray
         samples = [b'', b'u'*100000]
         for sample in samples:

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1117,7 +1117,7 @@ class SizeofTest(unittest.TestCase):
         # buffer
         # XXX
         # builtin_function_or_method
-        check(len, vsize('5P'))
+        check(len, size('5P'))
         # bytearray
         samples = [b'', b'u'*100000]
         for sample in samples:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1069,6 +1069,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/initconfig.h \
 		$(srcdir)/Include/cpython/interpreteridobject.h \
 		$(srcdir)/Include/cpython/listobject.h \
+		$(srcdir)/Include/cpython/methodobject.h \
 		$(srcdir)/Include/cpython/object.h \
 		$(srcdir)/Include/cpython/objimpl.h \
 		$(srcdir)/Include/cpython/pyerrors.h \

--- a/Misc/NEWS.d/next/C API/2020-01-22-12-38-59.bpo-38787.HUH6hd.rst
+++ b/Misc/NEWS.d/next/C API/2020-01-22-12-38-59.bpo-38787.HUH6hd.rst
@@ -1,0 +1,2 @@
+Module C state is now accessible from C-defined heap type methods. (PEP-573)
+Patch by Marcel Plch and Petr Viktorin.

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -792,7 +792,8 @@ PyInit__testmultiphase_exec_unreported_exception(PyObject *spec)
 }
 
 static int
-meth_state_access_exec(PyObject *m) {
+meth_state_access_exec(PyObject *m)
+{
     PyObject *temp;
     meth_state *m_state;
 
@@ -832,7 +833,8 @@ static PyModuleDef def_meth_state_access = {
 };
 
 PyMODINIT_FUNC
-PyInit__testmultiphase_meth_state_access(PyObject *spec) {
+PyInit__testmultiphase_meth_state_access(PyObject *spec)
+{
     return PyModuleDef_Init(&def_meth_state_access);
 }
 

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -12,9 +12,10 @@ typedef struct {
 
 /*[clinic input]
 module _testmultiphase
-class _testmultiphase.Example "ExampleObject *" "!Example"
+
+class _testmultiphase.StateAccessType "StateAccessTypeObject *" "!StateAccessType"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=cf7bf661ca0179b9]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=bab9f2fe3bd312ff]*/
 
 /* Example objects */
 typedef struct {
@@ -25,11 +26,6 @@ typedef struct {
 typedef struct {
     PyObject *integer;
 } testmultiphase_state;
-
-/*[clinic input]
-class _testmultiphase.StateAccessType "StateAccessTypeObject *" "!StateAccessType"
-[clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=5279c64c0c9ef77f]*/
 
 typedef struct {
     PyObject_HEAD
@@ -106,7 +102,6 @@ Example_setattr(ExampleObject *self, const char *name, PyObject *v)
         return PyDict_SetItemString(self->x_attr, name, v);
 }
 
-
 static PyType_Slot Example_Type_slots[] = {
     {Py_tp_doc, "The Example type"},
     {Py_tp_finalize, Example_finalize},
@@ -121,7 +116,7 @@ static PyType_Spec Example_Type_spec = {
     "_testimportexec.Example",
     sizeof(ExampleObject),
     0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     Example_Type_slots
 };
 
@@ -149,22 +144,32 @@ _testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *
 }
 
 /*[clinic input]
-_testmultiphase.StateAccessType.increment_count
+_testmultiphase.StateAccessType.increment_count_clinic
 
     cls: defining_class
+    /
+    n: int = 1
+    *
+    twice: bool = False
 
-Add 1 to the module-state counter.
+Add 'n' from the module-state counter.
+
+Pass 'twice' to double that amount.
 
 This tests Argument Clinic support for defining_class.
 [clinic start generated code]*/
 
 static PyObject *
-_testmultiphase_StateAccessType_increment_count_impl(StateAccessTypeObject *self,
-                                                     PyTypeObject *cls)
-/*[clinic end generated code: output=b78c77b78c6882e4 input=baa6b8c0525ccde3]*/
+_testmultiphase_StateAccessType_increment_count_clinic_impl(StateAccessTypeObject *self,
+                                                            PyTypeObject *cls,
+                                                            int n, int twice)
+/*[clinic end generated code: output=3b34f86bc5473204 input=551d482e1fe0b8f5]*/
 {
     meth_state *m_state = PyType_GetModuleState(cls);
-    m_state->counter++;
+    if (twice) {
+        n *= 2;
+    }
+    m_state->counter += n;
 
     Py_RETURN_NONE;
 }
@@ -173,22 +178,28 @@ PyDoc_STRVAR(_StateAccessType_decrement_count__doc__,
 "decrement_count($self, /, n=1, *, twice=None)\n"
 "--\n"
 "\n"
-"Subtract 'n' from the module-state counter.\n"
+"Add 'n' from the module-state counter.\n"
 "Pass 'twice' to double that amount.\n"
 "(This is to test both positional and keyword arguments.");
 
 // Intentionally does not use Argument Clinic
 static PyObject *
-_StateAccessType_decrement_count(StateAccessTypeObject *self,
-                                 PyTypeObject *defining_class,
-                                 PyObject *const *args,
-                                 Py_ssize_t nargs,
-                                 PyObject *kwnames)
+_StateAccessType_increment_count_noclinic(StateAccessTypeObject *self,
+                                          PyTypeObject *defining_class,
+                                          PyObject *const *args,
+                                          Py_ssize_t nargs,
+                                          PyObject *kwnames)
 {
     if (!_PyArg_CheckPositional("StateAccessTypeObject.decrement_count", nargs, 0, 1)) {
         return NULL;
     }
-    int coefficient = 1;
+    long n = 1;
+    if (nargs) {
+        n = PyLong_AsLong(args[0]);
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+    }
     if (kwnames && PyTuple_Check(kwnames)) {
         if (PyTuple_GET_SIZE(kwnames) > 1 ||
             PyUnicode_CompareWithASCIIString(
@@ -201,17 +212,10 @@ _StateAccessType_decrement_count(StateAccessTypeObject *self,
             );
             return NULL;
         }
-        coefficient = 2;
-    }
-    long n = 1;
-    if (nargs) {
-        n = PyLong_AsLong(args[0]);
-        if (PyErr_Occurred()) {
-            return NULL;
-        }
+        n *= 2;
     }
     meth_state *m_state = PyType_GetModuleState(defining_class);
-    m_state->counter -= n * coefficient;
+    m_state->counter += n;
 
     Py_RETURN_NONE;
 }
@@ -236,10 +240,10 @@ _testmultiphase_StateAccessType_get_count_impl(StateAccessTypeObject *self,
 static PyMethodDef StateAccessType_methods[] = {
     _TESTMULTIPHASE_STATEACCESSTYPE_GET_DEFINING_MODULE_METHODDEF
     _TESTMULTIPHASE_STATEACCESSTYPE_GET_COUNT_METHODDEF
-    _TESTMULTIPHASE_STATEACCESSTYPE_INCREMENT_COUNT_METHODDEF
+    _TESTMULTIPHASE_STATEACCESSTYPE_INCREMENT_COUNT_CLINIC_METHODDEF
     {
-        "decrement_count",
-        (PyCFunction)(void(*)(void))_StateAccessType_decrement_count,
+        "increment_count_noclinic",
+        (PyCFunction)(void(*)(void))_StateAccessType_increment_count_noclinic,
         METH_METHOD|METH_FASTCALL|METH_KEYWORDS,
         _StateAccessType_decrement_count__doc__
     },

--- a/Modules/clinic/_testmultiphase.c.h
+++ b/Modules/clinic/_testmultiphase.c.h
@@ -1,0 +1,96 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(_testmultiphase_StateAccessType_get_defining_module__doc__,
+"get_defining_module($self, /)\n"
+"--\n"
+"\n"
+"Return the module of the defining class.");
+
+#define _TESTMULTIPHASE_STATEACCESSTYPE_GET_DEFINING_MODULE_METHODDEF    \
+    {"get_defining_module", (PyCFunction)(void(*)(void))_testmultiphase_StateAccessType_get_defining_module, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_get_defining_module__doc__},
+
+static PyObject *
+_testmultiphase_StateAccessType_get_defining_module_impl(StateAccessTypeObject *self,
+                                                         PyTypeObject *cls);
+
+static PyObject *
+_testmultiphase_StateAccessType_get_defining_module(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = { NULL};
+    static _PyArg_Parser _parser = {":get_defining_module", _keywords, 0};
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser
+        )) {
+        goto exit;
+    }
+    return_value = _testmultiphase_StateAccessType_get_defining_module_impl(self, cls);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testmultiphase_StateAccessType_increment_count__doc__,
+"increment_count($self, /)\n"
+"--\n"
+"\n"
+"Add 1 to the module-state counter.\n"
+"\n"
+"This tests Argument Clinic support for defining_class.");
+
+#define _TESTMULTIPHASE_STATEACCESSTYPE_INCREMENT_COUNT_METHODDEF    \
+    {"increment_count", (PyCFunction)(void(*)(void))_testmultiphase_StateAccessType_increment_count, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_increment_count__doc__},
+
+static PyObject *
+_testmultiphase_StateAccessType_increment_count_impl(StateAccessTypeObject *self,
+                                                     PyTypeObject *cls);
+
+static PyObject *
+_testmultiphase_StateAccessType_increment_count(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = { NULL};
+    static _PyArg_Parser _parser = {":increment_count", _keywords, 0};
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser
+        )) {
+        goto exit;
+    }
+    return_value = _testmultiphase_StateAccessType_increment_count_impl(self, cls);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_testmultiphase_StateAccessType_get_count__doc__,
+"get_count($self, /)\n"
+"--\n"
+"\n"
+"Return the value of the module-state counter.");
+
+#define _TESTMULTIPHASE_STATEACCESSTYPE_GET_COUNT_METHODDEF    \
+    {"get_count", (PyCFunction)(void(*)(void))_testmultiphase_StateAccessType_get_count, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_get_count__doc__},
+
+static PyObject *
+_testmultiphase_StateAccessType_get_count_impl(StateAccessTypeObject *self,
+                                               PyTypeObject *cls);
+
+static PyObject *
+_testmultiphase_StateAccessType_get_count(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = { NULL};
+    static _PyArg_Parser _parser = {":get_count", _keywords, 0};
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser
+        )) {
+        goto exit;
+    }
+    return_value = _testmultiphase_StateAccessType_get_count_impl(self, cls);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=0a316f45389bb323 input=a9049054013a1b77]*/

--- a/Modules/clinic/_testmultiphase.c.h
+++ b/Modules/clinic/_testmultiphase.c.h
@@ -32,33 +32,38 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_testmultiphase_StateAccessType_increment_count__doc__,
-"increment_count($self, /)\n"
+PyDoc_STRVAR(_testmultiphase_StateAccessType_increment_count_clinic__doc__,
+"increment_count_clinic($self, /, n=1, *, twice=False)\n"
 "--\n"
 "\n"
-"Add 1 to the module-state counter.\n"
+"Add \'n\' from the module-state counter.\n"
+"\n"
+"Pass \'twice\' to double that amount.\n"
 "\n"
 "This tests Argument Clinic support for defining_class.");
 
-#define _TESTMULTIPHASE_STATEACCESSTYPE_INCREMENT_COUNT_METHODDEF    \
-    {"increment_count", (PyCFunction)(void(*)(void))_testmultiphase_StateAccessType_increment_count, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_increment_count__doc__},
+#define _TESTMULTIPHASE_STATEACCESSTYPE_INCREMENT_COUNT_CLINIC_METHODDEF    \
+    {"increment_count_clinic", (PyCFunction)(void(*)(void))_testmultiphase_StateAccessType_increment_count_clinic, METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _testmultiphase_StateAccessType_increment_count_clinic__doc__},
 
 static PyObject *
-_testmultiphase_StateAccessType_increment_count_impl(StateAccessTypeObject *self,
-                                                     PyTypeObject *cls);
+_testmultiphase_StateAccessType_increment_count_clinic_impl(StateAccessTypeObject *self,
+                                                            PyTypeObject *cls,
+                                                            int n, int twice);
 
 static PyObject *
-_testmultiphase_StateAccessType_increment_count(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_testmultiphase_StateAccessType_increment_count_clinic(StateAccessTypeObject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = { NULL};
-    static _PyArg_Parser _parser = {":increment_count", _keywords, 0};
+    static const char * const _keywords[] = {"n", "twice", NULL};
+    static _PyArg_Parser _parser = {"|i$p:increment_count_clinic", _keywords, 0};
+    int n = 1;
+    int twice = 0;
 
-    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser
-        )) {
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &n, &twice)) {
         goto exit;
     }
-    return_value = _testmultiphase_StateAccessType_increment_count_impl(self, cls);
+    return_value = _testmultiphase_StateAccessType_increment_count_clinic_impl(self, cls, n, twice);
 
 exit:
     return return_value;
@@ -93,4 +98,4 @@ _testmultiphase_StateAccessType_get_count(StateAccessTypeObject *self, PyTypeObj
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0a316f45389bb323 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=39eea487e94e7f5d input=a9049054013a1b77]*/

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -95,7 +95,6 @@ descr_check(PyDescrObject *descr, PyObject *obj, PyObject **pres)
 static PyObject *
 classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
 {
-    PyTypeObject *cls = NULL;
     /* Ensure a valid type.  Class methods ignore obj. */
     if (type == NULL) {
         if (obj != NULL)
@@ -128,6 +127,7 @@ classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
                      ((PyTypeObject *)type)->tp_name);
         return NULL;
     }
+    PyTypeObject *cls = NULL;
     if (descr->d_method->ml_flags & METH_METHOD) {
         cls = descr->d_common.d_type;
     }
@@ -926,7 +926,7 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
         case METH_O:
             vectorcall = method_vectorcall_O;
             break;
-        case METH_FASTCALL | METH_KEYWORDS | METH_METHOD:
+        case METH_METHOD | METH_FASTCALL | METH_KEYWORDS:
             vectorcall = method_vectorcall_FASTCALL_KEYWORDS_METHOD;
             break;
         default:

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -95,6 +95,7 @@ descr_check(PyDescrObject *descr, PyObject *obj, PyObject **pres)
 static PyObject *
 classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
 {
+    PyTypeObject *cls = NULL;
     /* Ensure a valid type.  Class methods ignore obj. */
     if (type == NULL) {
         if (obj != NULL)
@@ -127,7 +128,10 @@ classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
                      ((PyTypeObject *)type)->tp_name);
         return NULL;
     }
-    return PyCFunction_NewEx(descr->d_method, type, NULL);
+    if (descr->d_method->ml_flags & METH_METHOD) {
+        cls = descr->d_common.d_type;
+    }
+    return PyCMethod_New(descr->d_method, type, NULL, cls);
 }
 
 static PyObject *
@@ -137,7 +141,19 @@ method_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
 
     if (descr_check((PyDescrObject *)descr, obj, &res))
         return res;
-    return PyCFunction_NewEx(descr->d_method, obj, NULL);
+    if (descr->d_method->ml_flags & METH_METHOD) {
+        if (PyType_Check(type)) {
+            return PyCMethod_New(descr->d_method, obj, NULL, descr->d_common.d_type);
+        } else {
+            PyErr_Format(PyExc_TypeError,
+                        "descriptor '%V' needs a type, not '%s', as arg 2",
+                        descr_name((PyDescrObject *)descr),
+                        Py_TYPE(type)->tp_name);
+            return NULL;
+        }
+    } else {
+        return PyCFunction_NewEx(descr->d_method, obj, NULL);
+    }
 }
 
 static PyObject *
@@ -332,6 +348,27 @@ method_vectorcall_VARARGS_KEYWORDS(
 exit:
     Py_DECREF(argstuple);
     Py_XDECREF(kwdict);
+    return result;
+}
+
+static PyObject *
+method_vectorcall_FASTCALL_KEYWORDS_METHOD(
+    PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    if (method_check_args(func, args, nargs, NULL)) {
+        return NULL;
+    }
+     NULL;
+    PyCMethod meth = (PyCMethod) method_enter_call(tstate, func);
+    if (meth == NULL) {
+        return NULL;
+    }
+    PyObject *result = meth(args[0],
+                            ((PyMethodDescrObject *)func)->d_common.d_type,
+                            args+1, nargs-1, kwnames);
+    Py_LeaveRecursiveCall();
     return result;
 }
 
@@ -868,7 +905,8 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
 {
     /* Figure out correct vectorcall function to use */
     vectorcallfunc vectorcall;
-    switch (method->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O | METH_KEYWORDS))
+    switch (method->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS |
+                                METH_O | METH_KEYWORDS | METH_METHOD))
     {
         case METH_VARARGS:
             vectorcall = method_vectorcall_VARARGS;
@@ -887,6 +925,9 @@ PyDescr_NewMethod(PyTypeObject *type, PyMethodDef *method)
             break;
         case METH_O:
             vectorcall = method_vectorcall_O;
+            break;
+        case METH_FASTCALL | METH_KEYWORDS | METH_METHOD:
+            vectorcall = method_vectorcall_FASTCALL_KEYWORDS_METHOD;
             break;
         default:
             PyErr_Format(PyExc_SystemError,

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -10,11 +10,15 @@
 
 /* undefine macro trampoline to PyCFunction_NewEx */
 #undef PyCFunction_New
+/* undefine macro trampoline to PyCMethod_New */
+#undef PyCFunction_NewEx
 
 /* Forward declarations */
 static PyObject * cfunction_vectorcall_FASTCALL(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 static PyObject * cfunction_vectorcall_FASTCALL_KEYWORDS(
+    PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
+static PyObject * cfunction_vectorcall_FASTCALL_KEYWORDS_METHOD(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
 static PyObject * cfunction_vectorcall_NOARGS(
     PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames);
@@ -33,9 +37,16 @@ PyCFunction_New(PyMethodDef *ml, PyObject *self)
 PyObject *
 PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
 {
+    return PyCMethod_New(ml, self, module, NULL);
+}
+
+PyObject *
+PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *cls)
+{
     /* Figure out correct vectorcall function to use */
     vectorcallfunc vectorcall;
-    switch (ml->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O | METH_KEYWORDS))
+    switch (ml->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS |
+                            METH_O | METH_KEYWORDS | METH_METHOD))
     {
         case METH_VARARGS:
         case METH_VARARGS | METH_KEYWORDS:
@@ -55,17 +66,45 @@ PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
         case METH_O:
             vectorcall = cfunction_vectorcall_O;
             break;
+        case METH_FASTCALL | METH_KEYWORDS | METH_METHOD:
+            vectorcall = cfunction_vectorcall_FASTCALL_KEYWORDS_METHOD;
+            break;
         default:
             PyErr_Format(PyExc_SystemError,
                          "%s() method: bad call flags", ml->ml_name);
             return NULL;
     }
 
-    PyCFunctionObject *op =
-        PyObject_GC_New(PyCFunctionObject, &PyCFunction_Type);
-    if (op == NULL) {
-        return NULL;
+    PyCFunctionObject *op = NULL;
+
+    if (ml->ml_flags & METH_METHOD) {
+        if (!cls) {
+            PyErr_SetString(PyExc_SystemError,
+                            "attempting to create PyCMethod with a METH_METHOD "
+                            "flag but no class");
+            return NULL;
+        }
+        PyCMethodObject *om = PyObject_GC_New(PyCMethodObject, &PyCMethod_Type);
+        if (om == NULL) {
+            return NULL;
+        }
+        Py_INCREF(cls);
+        om->mm_class = cls;
+        op = (PyCFunctionObject *)om;
+    } else {
+        if (cls) {
+            PyErr_SetString(PyExc_SystemError,
+                            "attempting to create PyCFunction with class "
+                            "but no METH_METHOD flag");
+            return NULL;
+        }
+        else {
+            op = PyObject_GC_New(PyCFunctionObject, &PyCFunction_Type);
+            if (op == NULL)
+                return NULL;
+        }
     }
+
     op->m_weakreflist = NULL;
     op->m_ml = ml;
     Py_XINCREF(self);
@@ -107,6 +146,16 @@ PyCFunction_GetFlags(PyObject *op)
     return PyCFunction_GET_FLAGS(op);
 }
 
+PyTypeObject *
+PyCMethod_GetClass(PyObject *op)
+{
+    if (!PyCFunction_Check(op)) {
+        PyErr_BadInternalCall();
+        return NULL;
+    }
+    return PyCFunction_GET_CLASS(op);
+}
+
 /* Methods (the standard built-in methods, that is) */
 
 static void
@@ -118,6 +167,7 @@ meth_dealloc(PyCFunctionObject *m)
     }
     Py_XDECREF(m->m_self);
     Py_XDECREF(m->m_module);
+    Py_XDECREF(PyCFunction_GET_CLASS(m));
     PyObject_GC_Del(m);
 }
 
@@ -196,6 +246,8 @@ meth_traverse(PyCFunctionObject *m, visitproc visit, void *arg)
 {
     Py_VISIT(m->m_self);
     Py_VISIT(m->m_module);
+    Py_VISIT(PyCFunction_GET_CLASS(m));
+
     return 0;
 }
 
@@ -314,6 +366,26 @@ PyTypeObject PyCFunction_Type = {
     0,                                          /* tp_dict */
 };
 
+PyTypeObject PyCMethod_Type = {
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    .tp_name = "builtin_c_method",
+    .tp_basicsize = sizeof(PyCMethodObject),
+    .tp_dealloc = (destructor)meth_dealloc,
+    .tp_repr = (reprfunc)meth_repr,
+    .tp_hash = (hashfunc)meth_hash,
+    .tp_call = cfunction_call,
+    .tp_getattro = PyObject_GenericGetAttr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)meth_traverse,
+    .tp_richcompare = meth_richcompare,
+    .tp_weaklistoffset = offsetof(PyCFunctionObject, m_weakreflist),
+    .tp_methods = meth_methods,
+    .tp_members = meth_members,
+    .tp_getset = meth_getsets,
+    .tp_base = &PyCFunction_Type,
+    .tp_vectorcall_offset = offsetof(PyCFunctionObject, vectorcall),
+};
+
 /* Vectorcall functions for each of the PyCFunction calling conventions,
  * except for METH_VARARGS (possibly combined with METH_KEYWORDS) which
  * doesn't use vectorcall.
@@ -381,6 +453,22 @@ cfunction_vectorcall_FASTCALL_KEYWORDS(
         return NULL;
     }
     PyObject *result = meth(PyCFunction_GET_SELF(func), args, nargs, kwnames);
+    _Py_LeaveRecursiveCall(tstate);
+    return result;
+}
+
+static PyObject *
+cfunction_vectorcall_FASTCALL_KEYWORDS_METHOD(
+    PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+{
+    PyThreadState *tstate = _PyThreadState_GET();
+    PyTypeObject *cls = PyCFunction_GET_CLASS(func);
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+    PyCMethod meth = (PyCMethod)cfunction_enter_call(tstate, func);
+    if (meth == NULL) {
+        return NULL;
+    }
+    PyObject *result = meth(PyCFunction_GET_SELF(func), cls, args, nargs, kwnames);
     _Py_LeaveRecursiveCall(tstate);
     return result;
 }

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -66,7 +66,7 @@ PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *c
         case METH_O:
             vectorcall = cfunction_vectorcall_O;
             break;
-        case METH_FASTCALL | METH_KEYWORDS | METH_METHOD:
+        case METH_METHOD | METH_FASTCALL | METH_KEYWORDS:
             vectorcall = cfunction_vectorcall_FASTCALL_KEYWORDS_METHOD;
             break;
         default:

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -84,7 +84,10 @@ PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *c
                             "flag but no class");
             return NULL;
         }
-        PyCMethodObject *om = PyObject_GC_New(PyCMethodObject, &PyCMethod_Type);
+        PyCMethodObject *om = PyObject_GC_NewVar(
+            PyCMethodObject,
+            &PyCFunction_Type,
+            sizeof(PyCMethodObject) - sizeof(PyCFunctionObject));
         if (om == NULL) {
             return NULL;
         }
@@ -99,7 +102,7 @@ PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *c
             return NULL;
         }
         else {
-            op = PyObject_GC_New(PyCFunctionObject, &PyCFunction_Type);
+            op = PyObject_GC_NewVar(PyCFunctionObject, &PyCFunction_Type, 0);
             if (op == NULL)
                 return NULL;
         }
@@ -334,7 +337,7 @@ PyTypeObject PyCFunction_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "builtin_function_or_method",
     sizeof(PyCFunctionObject),
-    0,
+    1,
     (destructor)meth_dealloc,                   /* tp_dealloc */
     offsetof(PyCFunctionObject, vectorcall),    /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
@@ -364,26 +367,6 @@ PyTypeObject PyCFunction_Type = {
     meth_getsets,                               /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
-};
-
-PyTypeObject PyCMethod_Type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    .tp_name = "builtin_c_method",
-    .tp_basicsize = sizeof(PyCMethodObject),
-    .tp_dealloc = (destructor)meth_dealloc,
-    .tp_repr = (reprfunc)meth_repr,
-    .tp_hash = (hashfunc)meth_hash,
-    .tp_call = cfunction_call,
-    .tp_getattro = PyObject_GenericGetAttr,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_traverse = (traverseproc)meth_traverse,
-    .tp_richcompare = meth_richcompare,
-    .tp_weaklistoffset = offsetof(PyCFunctionObject, m_weakreflist),
-    .tp_methods = meth_methods,
-    .tp_members = meth_members,
-    .tp_getset = meth_getsets,
-    .tp_base = &PyCFunction_Type,
-    .tp_vectorcall_offset = offsetof(PyCFunctionObject, vectorcall),
 };
 
 /* Vectorcall functions for each of the PyCFunction calling conventions,

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -368,22 +368,9 @@ PyTypeObject PyCFunction_Type = {
 
 PyTypeObject PyCMethod_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    .tp_name = "builtin_c_method",
+    .tp_name = "builtin_method",
     .tp_basicsize = sizeof(PyCMethodObject),
-    .tp_dealloc = (destructor)meth_dealloc,
-    .tp_repr = (reprfunc)meth_repr,
-    .tp_hash = (hashfunc)meth_hash,
-    .tp_call = cfunction_call,
-    .tp_getattro = PyObject_GenericGetAttr,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_traverse = (traverseproc)meth_traverse,
-    .tp_richcompare = meth_richcompare,
-    .tp_weaklistoffset = offsetof(PyCFunctionObject, m_weakreflist),
-    .tp_methods = meth_methods,
-    .tp_members = meth_members,
-    .tp_getset = meth_getsets,
     .tp_base = &PyCFunction_Type,
-    .tp_vectorcall_offset = offsetof(PyCFunctionObject, vectorcall),
 };
 
 /* Vectorcall functions for each of the PyCFunction calling conventions,

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -98,10 +98,9 @@ PyCMethod_New(PyMethodDef *ml, PyObject *self, PyObject *module, PyTypeObject *c
                             "but no METH_METHOD flag");
             return NULL;
         }
-        else {
-            op = PyObject_GC_New(PyCFunctionObject, &PyCFunction_Type);
-            if (op == NULL)
-                return NULL;
+        op = PyObject_GC_New(PyCFunctionObject, &PyCFunction_Type);
+        if (op == NULL) {
+            return NULL;
         }
     }
 
@@ -247,7 +246,6 @@ meth_traverse(PyCFunctionObject *m, visitproc visit, void *arg)
     Py_VISIT(m->m_self);
     Py_VISIT(m->m_module);
     Py_VISIT(PyCFunction_GET_CLASS(m));
-
     return 0;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1789,6 +1789,7 @@ _PyTypes_Init(void)
     INIT_TYPE(&PyCode_Type, "code");
     INIT_TYPE(&PyFrame_Type, "frame");
     INIT_TYPE(&PyCFunction_Type, "builtin function");
+    INIT_TYPE(&PyCMethod_Type, "builtin method");
     INIT_TYPE(&PyMethod_Type, "method");
     INIT_TYPE(&PyFunction_Type, "function");
     INIT_TYPE(&PyDictProxy_Type, "dict proxy");

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3081,7 +3081,8 @@ PyType_GetSlot(PyTypeObject *type, int slot)
 }
 
 PyObject *
-PyType_GetModule(PyTypeObject *type) {
+PyType_GetModule(PyTypeObject *type)
+{
     assert(PyType_Check(type));
     if (!_PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
         PyErr_Format(
@@ -3104,7 +3105,8 @@ PyType_GetModule(PyTypeObject *type) {
 }
 
 void *
-PyType_GetModuleState(PyTypeObject *type) {
+PyType_GetModuleState(PyTypeObject *type)
+{
     PyObject *m = PyType_GetModule(type);
     if (m == NULL) {
         return NULL;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3082,7 +3082,8 @@ PyType_GetSlot(PyTypeObject *type, int slot)
 
 PyObject *
 PyType_GetModule(PyTypeObject *type) {
-    if (!PyType_Check(type) || !PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
+    assert(PyType_Check(type));
+    if (!_PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
         PyErr_Format(
             PyExc_TypeError,
             "PyType_GetModule: Type '%s' is not a heap type",
@@ -3104,14 +3105,10 @@ PyType_GetModule(PyTypeObject *type) {
 
 void *
 PyType_GetModuleState(PyTypeObject *type) {
-    PyObject *m;
-
-    m = PyType_GetModule(type);
-
+    PyObject *m = PyType_GetModule(type);
     if (m == NULL) {
         return NULL;
     }
-
     return PyModule_GetState(m);
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3080,6 +3080,41 @@ PyType_GetSlot(PyTypeObject *type, int slot)
     return  *(void**)(((char*)type) + slotoffsets[slot]);
 }
 
+PyObject *
+PyType_GetModule(PyTypeObject *type) {
+    if (!PyType_Check(type) || !PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "PyType_GetModule: Type '%s' is not a heap type",
+            type->tp_name);
+        return NULL;
+    }
+
+    PyHeapTypeObject* et = (PyHeapTypeObject*)type;
+    if (!et->ht_module) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "PyType_GetModule: Type '%s' has no associated module",
+            type->tp_name);
+        return NULL;
+    }
+    return et->ht_module;
+
+}
+
+void *
+PyType_GetModuleState(PyTypeObject *type) {
+    PyObject *m;
+
+    m = PyType_GetModule(type);
+
+    if (m == NULL) {
+        return NULL;
+    }
+
+    return PyModule_GetState(m);
+}
+
 /* Internal API to look for a name through the MRO, bypassing the method cache.
    This returns a borrowed reference, and might set an exception.
    'error' is set to: -1: error with exception; 1: error without exception; 0: ok */

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -135,6 +135,7 @@
     <ClInclude Include="..\Include\cpython\import.h" />
     <ClInclude Include="..\Include\cpython\initconfig.h" />
     <ClInclude Include="..\Include\cpython\listobject.h" />
+    <ClInclude Include="..\Include\cpython\methodobject.h" />
     <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />
     <ClInclude Include="..\Include\cpython\pyerrors.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClInclude Include="..\Include\cpython\listobject.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\methodobject.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\object.h">
       <Filter>Include</Filter>
     </ClInclude>


### PR DESCRIPTION
WIP PEP 573 implementation. Not yet ready to send as a PR to CPython.
@dormouse759  @vstinner, do you want to comment?

Look at the diff rather than individual commits. Lots of changes have been reverted/rebased. Marcel started the implementation in 2017.

There's still lots to do:

* [x] Make sure this matches all of the text in the PEP
  * [x] Argument Clinic: Check the new argument doesn not appear in `__text_signature__`.
* [x] Try not subclassing `PyCMethod` from `PyCFunction`
* [x] Add documentation
* [x] Move tests to a better place
* [ ] Add more tests?
* [ ] Convert a stdlib module or two
etc.
